### PR TITLE
Feat/hmac algorithm options

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ npm i @autotelic/fastify-hmac
 - Register plugin. This will decorate your `fastify` instance with a request method `HMACValidate`.
   - During registration, provide a configuration object that contains the following:
     - A `sharedSecret` string
-    - A `algorithmMap` object that maps Signature header `algorithm` and `keyId` properties to a specific algorithm
-    - A `getSignatureEncoding` function that returns a digest string
+    - A `algorithmMap` object that maps Signature header `algorithm` and `keyId` properties to a specific algorithm. See [`getAlgorithm`](#default-getAlgorithm-method) for default structure.
+    - A `getSignatureEncoding` function that returns a encoding string to be used during HMAC signature construction. e.g. `'base64'` or `'hex'`
     - Optional configuration properties
       - A `verificationError` string - default: 'Unauthorized'
       - A `verificationErrorMessage` string - default: 'Signature verification failed'

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ npm i @autotelic/fastify-hmac
 - Register plugin. This will decorate your `fastify` instance with a request method `HMACValidate`.
   - During registration, provide a configuration object that contains the following:
     - A `sharedSecret` string
-    - A `getAlgorithm` function that returns an algorithm string
+    - A `algorithmMap` object that maps Signature header `algorithm` and `keyId` properties to a specific algorithm
     - A `getSignatureEncoding` function that returns a digest string
     - Optional configuration properties
       - A `verificationError` string - default: 'Unauthorized'
@@ -28,6 +28,7 @@ npm i @autotelic/fastify-hmac
       - A `getDigest` method - [default](#default-getDigest-method): A method that calculates and verifies a message Digest header to be used as input to the HMAC signature.
       - A `extractSignature` method - [default](#default-extractSignature-method): A method that extracts properties from a request Signature Header constructed according to [IETF draft standards][1]
       - A `constructSignatureString` method - [default](#default-constructSignatureString-method): A method that constructs a Signature digest string from the key material detailed in the request Signature header according to [IETF draft standards][1]
+      - A `getAlgorithm` method - [default](#default-getAlgorithm-method): A method that returns an algorithm string from the `algorithmMap` configuration object.
 - Add a [global](#global-hook-example) or [route level](#route-level-hook-example) `preValidation` hook to your application.
   - **Note:** For verification of HMAC signatures that include a body Digest header as HMAC key material, the `validateHMAC` step must take place on the `preValidation` lifecycle step as the fastify request body parsing takes place just prior to `preValidation`. Prior to `preValidation`, `request.body` will always be `null`.
 
@@ -37,10 +38,14 @@ npm i @autotelic/fastify-hmac
 module.exports = function (fastify, options, next) {
   fastify.register(require('fastify-hmac'), {
     sharedSecret: 'topSecret',
-    getAlgorithm: () => 'sha512',
+    algorithmMap: {
+      hs2019: {
+        'test-key-a': 'sha512',
+        'test-key-b': 'sha256'
+      }
+    },
     getSignatureEncoding: () => 'base64'
   })
-
   fastify.addHook('preValidation', (request, reply, next) => {
     try {
       request.validateHMAC(request, reply, next)
@@ -53,9 +58,14 @@ module.exports = function (fastify, options, next) {
     reply.type('application/json')
     reply.send({ hello: 'hmac' })
   })
+
+  fastify.post('/foo', (req, reply) => {
+    reply.type('application/json')
+    reply.send({ hello: 'foo' })
+  })
+
   next()
 }
-
 ```
 
 #### Run the example:
@@ -70,7 +80,12 @@ npm run example:hook -- -l info -w
 module.exports = function (fastify, options, next) {
   fastify.register(require('fastify-hmac'), {
     sharedSecret: 'topSecret',
-    getAlgorithm: () => 'sha512',
+    algorithmMap: {
+      hs2019: {
+        'test-key-a': 'sha512',
+        'test-key-b': 'sha256'
+      }
+    },
     getSignatureEncoding: () => 'base64'
   })
 
@@ -97,7 +112,6 @@ module.exports = function (fastify, options, next) {
     })
   next()
 }
-
 ```
 
 #### Run the example:
@@ -108,7 +122,7 @@ npm run example:decorator -- -l info -w
 
 ### Example: Shopify HMAC Query Parameter Verification
 
-The `extractSignature` and `constructSignatureString` methods can also be entirely replaced during registration by passing in new methods. This example shows how this plugin can be modified to verify Shopify Query String HMAC parameters instead of Signature headers. 
+The `extractSignature`, `constructSignatureString` and `getAlgorithm` methods can also be entirely replaced during registration by passing in new methods. This example shows how this plugin can be modified to verify Shopify Query String HMAC parameters instead of Signature headers. 
 
 ```js
 const {
@@ -156,6 +170,10 @@ npm run example:shopify -- -l info -w
 **TODO**
 
 ## Default getDigest Method
+
+**TODO**
+
+## Default getAlgorithm Method
 
 **TODO**
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ npm i @autotelic/fastify-hmac
 - Register plugin. This will decorate your `fastify` instance with a request method `HMACValidate`.
   - During registration, provide a configuration object that contains the following:
     - A `sharedSecret` string
-    - A `algorithmMap` object that maps Signature header `algorithm` and `keyId` properties to a specific algorithm. See [`getAlgoithm`](#default-getAlgorithm-method) for default structure.
-    - A `getSignatureEncoding` function that returns a encoding string to be used during HMAC signature construction. e.g. `'base64'` or `'hex'`
+    - A `algorithmMap` object that maps Signature header `algorithm` and `keyId` properties to a specific algorithm
+    - A `getSignatureEncoding` function that returns a digest string
     - Optional configuration properties
       - A `verificationError` string - default: 'Unauthorized'
       - A `verificationErrorMessage` string - default: 'Signature verification failed'

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ npm i @autotelic/fastify-hmac
 - Register plugin. This will decorate your `fastify` instance with a request method `HMACValidate`.
   - During registration, provide a configuration object that contains the following:
     - A `sharedSecret` string
-    - A `algorithmMap` object that maps Signature header `algorithm` and `keyId` properties to a specific algorithm
-    - A `getSignatureEncoding` function that returns a digest string
+    - A `algorithmMap` object that maps Signature header `algorithm` and `keyId` properties to a specific algorithm. See [`getAlgoithm`](#default-getAlgorithm-method) for default structure.
+    - A `getSignatureEncoding` function that returns a encoding string to be used during HMAC signature construction. e.g. `'base64'` or `'hex'`
     - Optional configuration properties
       - A `verificationError` string - default: 'Unauthorized'
       - A `verificationErrorMessage` string - default: 'Signature verification failed'

--- a/examples/exampleDecorator.js
+++ b/examples/exampleDecorator.js
@@ -5,7 +5,12 @@ const hmac = require('../')
 module.exports = function (fastify, options, next) {
   fastify.register(hmac, {
     sharedSecret: 'topSecret',
-    getAlgorithm: () => 'sha512',
+    algorithmMap: {
+      hs2019: {
+        'test-key-a': 'sha512',
+        'test-key-b': 'sha256'
+      }
+    },
     getSignatureEncoding: () => 'base64'
   })
 

--- a/examples/exampleHook.js
+++ b/examples/exampleHook.js
@@ -5,7 +5,16 @@ const hmac = require('../')
 module.exports = function (fastify, options, next) {
   fastify.register(hmac, {
     sharedSecret: 'topSecret',
-    getAlgorithm: () => 'sha512',
+    getKeyIdMap: () => ({
+      'test-key-a': {
+        name: 'hs2019',
+        algorithm: 'sha512'
+      },
+      'test-key-b': {
+        name: 'hs2019',
+        algorithm: 'sha256'
+      }
+    }),
     getSignatureEncoding: () => 'base64'
   })
   fastify.addHook('preValidation', (request, reply, next) => {

--- a/examples/exampleHook.js
+++ b/examples/exampleHook.js
@@ -5,16 +5,12 @@ const hmac = require('../')
 module.exports = function (fastify, options, next) {
   fastify.register(hmac, {
     sharedSecret: 'topSecret',
-    getKeyIdMap: () => ({
-      'test-key-a': {
-        name: 'hs2019',
-        algorithm: 'sha512'
-      },
-      'test-key-b': {
-        name: 'hs2019',
-        algorithm: 'sha256'
+    algorithmMap: {
+      hs2019: {
+        'test-key-a': 'sha512',
+        'test-key-b': 'sha256'
       }
-    }),
+    },
     getSignatureEncoding: () => 'base64'
   })
   fastify.addHook('preValidation', (request, reply, next) => {
@@ -29,5 +25,11 @@ module.exports = function (fastify, options, next) {
     reply.type('application/json')
     reply.send({ hello: 'hmac' })
   })
+
+  fastify.post('/foo', (req, reply) => {
+    reply.type('application/json')
+    reply.send({ hello: 'foo' })
+  })
+
   next()
 }

--- a/lib/constructSignatureString.js
+++ b/lib/constructSignatureString.js
@@ -5,7 +5,7 @@ const parseSignatureHeader = require('./parseSignatureHeader')
 
 const constructSignatureString = (req, options) =>
   calculateSignature({
-    algorithm: options.getAlgorithm(),
+    algorithm: options.getAlgorithm(req, options),
     sharedSecret: options.sharedSecret,
     message: getMessage(req, options),
     encoding: options.getSignatureEncoding()

--- a/lib/constructSignatureString.test.js
+++ b/lib/constructSignatureString.test.js
@@ -8,16 +8,12 @@ const getAlgorithm = require('./getAlgorithm')
 const defaultOptions = {
   sharedSecret: 'topSecret',
   getAlgorithm,
-  getKeyIdMap: () => ({
-    'test-key-a': {
-      name: 'hs2019',
-      algorithm: 'sha512'
-    },
-    'test-key-b': {
-      name: 'hs2019',
-      algorithm: 'sha256'
+  algorithmMap: {
+    hs2019: {
+      'test-key-a': 'sha512',
+      'test-key-b': 'sha256'
     }
-  }),
+  },
   getSignatureEncoding: () => 'base64',
   getDigest,
   digestEncoding: 'base64'
@@ -26,7 +22,7 @@ const defaultSignature =
   'Nstb3q49bne90WmkbiZ9eyRtKCUmOWvc/kFyw/ftfLtqAXfRZGBk+hSJkXs0GRRm4Q/58c/pdIKj5DND11/fwQ=='
 const defaultRequest = {
   headers: {
-    signature: `keyId="test-key-a", headers="(request-target) (created) (expires) host", signature="${defaultSignature}", created=1402170695, expires=1402170895`,
+    signature: `keyId="test-key-a", algorithm="hs2019", headers="(request-target) (created) (expires) host", signature="${defaultSignature}", created=1402170695, expires=1402170895`,
     host: 'localhost:3000'
   },
   raw: { method: 'POST', url: '/' }
@@ -50,7 +46,7 @@ test('Constructs a signature string from the incoming request', async ({
         'Matching signature constructed when a valid request using a digest header is provided',
       input: {
         headers: {
-          signature: 'keyId="test-key-a", headers="(request-target) (created) (expires) host digest content-type", signature="pQul5YFrqv76Zq2bE1kWjJfFGnTu0MwU7X7c8MWDswAI5V7dROqKbBWKUGcoysxujgTqkJo/Eg74x34o54hqRg==", created=1402170695, expires=1402170895',
+          signature: 'keyId="test-key-a", algorithm="hs2019", headers="(request-target) (created) (expires) host digest content-type", signature="pQul5YFrqv76Zq2bE1kWjJfFGnTu0MwU7X7c8MWDswAI5V7dROqKbBWKUGcoysxujgTqkJo/Eg74x34o54hqRg==", created=1402170695, expires=1402170895',
           host: 'localhost:3000',
           digest: 'sha-512=+PtokCNHosgo04ww4cNhd4yJxhMjLzWjDAKtKwQZDT4Ef9v/PrS/+BQLX4IX5dZkUMK/tQo7Uyc68RkhNyCZVg==',
           'content-type': 'application/json'

--- a/lib/constructSignatureString.test.js
+++ b/lib/constructSignatureString.test.js
@@ -3,10 +3,21 @@
 const { test } = require('tap')
 const constructSignatureString = require('./constructSignatureString')
 const getDigest = require('./getDigest')
+const getAlgorithm = require('./getAlgorithm')
 
 const defaultOptions = {
   sharedSecret: 'topSecret',
-  getAlgorithm: () => 'sha512',
+  getAlgorithm,
+  getKeyIdMap: () => ({
+    'test-key-a': {
+      name: 'hs2019',
+      algorithm: 'sha512'
+    },
+    'test-key-b': {
+      name: 'hs2019',
+      algorithm: 'sha256'
+    }
+  }),
   getSignatureEncoding: () => 'base64',
   getDigest,
   digestEncoding: 'base64'
@@ -15,7 +26,7 @@ const defaultSignature =
   'Nstb3q49bne90WmkbiZ9eyRtKCUmOWvc/kFyw/ftfLtqAXfRZGBk+hSJkXs0GRRm4Q/58c/pdIKj5DND11/fwQ=='
 const defaultRequest = {
   headers: {
-    signature: `keyId="key-a", headers="(request-target) (created) (expires) host", signature="${defaultSignature}", created=1402170695, expires=1402170895`,
+    signature: `keyId="test-key-a", headers="(request-target) (created) (expires) host", signature="${defaultSignature}", created=1402170695, expires=1402170895`,
     host: 'localhost:3000'
   },
   raw: { method: 'POST', url: '/' }
@@ -39,7 +50,7 @@ test('Constructs a signature string from the incoming request', async ({
         'Matching signature constructed when a valid request using a digest header is provided',
       input: {
         headers: {
-          signature: 'keyId="key-a", headers="(request-target) (created) (expires) host digest content-type", signature="pQul5YFrqv76Zq2bE1kWjJfFGnTu0MwU7X7c8MWDswAI5V7dROqKbBWKUGcoysxujgTqkJo/Eg74x34o54hqRg==", created=1402170695, expires=1402170895',
+          signature: 'keyId="test-key-a", headers="(request-target) (created) (expires) host digest content-type", signature="pQul5YFrqv76Zq2bE1kWjJfFGnTu0MwU7X7c8MWDswAI5V7dROqKbBWKUGcoysxujgTqkJo/Eg74x34o54hqRg==", created=1402170695, expires=1402170895',
           host: 'localhost:3000',
           digest: 'sha-512=+PtokCNHosgo04ww4cNhd4yJxhMjLzWjDAKtKwQZDT4Ef9v/PrS/+BQLX4IX5dZkUMK/tQo7Uyc68RkhNyCZVg==',
           'content-type': 'application/json'

--- a/lib/getAlgorithm.js
+++ b/lib/getAlgorithm.js
@@ -2,17 +2,17 @@
 
 const parseSignatureHeader = require('./parseSignatureHeader')
 
-const getAlgorithm = (req, { getKeyIdMap }) => {
+const getAlgorithm = (req, { algorithmMap }) => {
   const { keyId, algorithm } = parseSignatureHeader(req)
 
-  const { name, algorithm: algorithmFromMap } = getKeyIdMap()[keyId] || {}
-
-  if (!algorithmFromMap) {
-    throw new Error('No algorithm found in algorithmMap for this keyId')
+  if (!algorithmMap[algorithm]) {
+    throw new Error('No entry for this algorithm in algorithmMap')
   }
 
-  if (algorithm && algorithm !== name) {
-    throw new Error('Algorithm from keyId is not compatible with algorithm signature header parameter')
+  const algorithmFromMap = algorithmMap[algorithm][keyId]
+
+  if (!algorithmFromMap) {
+    throw new Error('No entry for this keyId in algorithmMap')
   }
 
   return algorithmFromMap

--- a/lib/getAlgorithm.js
+++ b/lib/getAlgorithm.js
@@ -2,10 +2,10 @@
 
 const parseSignatureHeader = require('./parseSignatureHeader')
 
-const getAlgorithm = (req, { algorithmMap }) => {
+const getAlgorithm = (req, { getKeyIdMap }) => {
   const { keyId, algorithm } = parseSignatureHeader(req)
 
-  const { name, algorithm: algorithmFromMap } = algorithmMap[keyId] || {}
+  const { name, algorithm: algorithmFromMap } = getKeyIdMap()[keyId] || {}
 
   if (!algorithmFromMap) {
     throw new Error('No algorithm found in algorithmMap for this keyId')

--- a/lib/getAlgorithm.js
+++ b/lib/getAlgorithm.js
@@ -1,0 +1,5 @@
+const getAlgorithm = (req, options) => {
+  return 'sha512'
+}
+
+module.exports = getAlgorithm

--- a/lib/getAlgorithm.js
+++ b/lib/getAlgorithm.js
@@ -1,5 +1,21 @@
-const getAlgorithm = (req, options) => {
-  return 'sha512'
+'use strict'
+
+const parseSignatureHeader = require('./parseSignatureHeader')
+
+const getAlgorithm = (req, { algorithmMap }) => {
+  const { keyId, algorithm } = parseSignatureHeader(req)
+
+  const { name, algorithm: algorithmFromMap } = algorithmMap[keyId] || {}
+
+  if (!algorithmFromMap) {
+    throw new Error('No algorithm found in algorithmMap for this keyId')
+  }
+
+  if (algorithm && algorithm !== name) {
+    throw new Error('Algorithm from keyId is not compatible with algorithm signature header parameter')
+  }
+
+  return algorithmFromMap
 }
 
 module.exports = getAlgorithm

--- a/lib/getAlgorithm.test.js
+++ b/lib/getAlgorithm.test.js
@@ -11,17 +11,34 @@ function createRequest (signature) {
   }
 }
 
+const defaultOptions = {
+  algorithmMap: {
+    'test-key-a': {
+      name: 'hs2019',
+      algorithm: 'sha512'
+    },
+    'test-key-b': {
+      name: 'hs2019',
+      algorithm: 'sha256'
+    }
+  }
+}
+
 test('Constructs a matching Digest header from a valid request Digest header and body', async ({
   equal
 }) => {
   const tests = [
     {
       description: 'Matching Digest header constructed from an incoming request - sha256',
-      input: createRequest('keyId="test-key-a", algorithm="hs2019", created=1402170695, headers="(request-target) (created)", signature="KXUj1H3ZOhv3Nk4xlRLTn4bOMlMOmFiud3VXrMa9MaLCxnVmrqOX5BulRvB65YW/wQp0oT/nNQpXgOYeY8ovmHlpkRyz5buNDqoOpRsCpLGxsIJ9cX8XVsM9jy+Q1+RIlD9wfWoPHhqhoXt35ZkasuIDPF/AETuObs9QydlsqONwbK+TdQguDK/8Va1Pocl6wK1uLwqcXlxhPEb55EmdYB9pddDyHTADING7K4qMwof2mC3t8Pb0yoLZoZX5a4Or4FrCCKK/9BHAhq/RsVk0dTENMbTB4i7cHvKQu+o9xuYWuxyvBa0Z6NdOb0di70cdrSDEsL5Gz7LBY5J2N9KdGg=="'),
-      options: {
-        algorithmMap: {}
-      },
+      input: createRequest('keyId="test-key-a", algorithm="hs2019", created=1402170695, headers="(request-target) (created)", signature="someSignature"'),
+      options: defaultOptions,
       expected: 'sha512'
+    },
+    {
+      description: 'Matching Digest header constructed from an incoming request - sha256',
+      input: createRequest('keyId="test-key-b", algorithm="hs2019", created=1402170695, headers="(request-target) (created)", signature="someSignature"'),
+      options: defaultOptions,
+      expected: 'sha256'
     }
   ]
 
@@ -30,18 +47,24 @@ test('Constructs a matching Digest header from a valid request Digest header and
   })
 })
 
-test('Throws an error when algorithm cannot be returned', async ({
+test('Throws an error when algorithm value cannot be returned', async ({
   throws
 }) => {
   const tests = [
     {
       description: 'Algorithm from keyId lookup is not compatible with algorithm signature header parameter',
-      input: createRequest(''),
-      options: {
-        algorithmMap: {}
-      },
+      input: createRequest('keyId="test-key-a", algorithm="RSA-256", created=1402170695, headers="(request-target) (created)", signature="someSignature"'),
+      options: defaultOptions,
       expected: new Error(
         'Algorithm from keyId is not compatible with algorithm signature header parameter'
+      )
+    },
+    {
+      description: 'keyId lookup does not result in an algorithm',
+      input: createRequest('keyId="test-key-c", algorithm="hs2019", created=1402170695, headers="(request-target) (created)", signature="someSignature"'),
+      options: defaultOptions,
+      expected: new Error(
+        'No algorithm found in algorithmMap for this keyId'
       )
     }
   ]

--- a/lib/getAlgorithm.test.js
+++ b/lib/getAlgorithm.test.js
@@ -12,16 +12,12 @@ function createRequest (signature) {
 }
 
 const defaultOptions = {
-  getKeyIdMap: () => ({
-    'test-key-a': {
-      name: 'hs2019',
-      algorithm: 'sha512'
-    },
-    'test-key-b': {
-      name: 'hs2019',
-      algorithm: 'sha256'
+  algorithmMap: {
+    hs2019: {
+      'test-key-a': 'sha512',
+      'test-key-b': 'sha256'
     }
-  })
+  }
 }
 
 test('Returns an algorithm string based on Signature header keyId value', async ({
@@ -56,7 +52,7 @@ test('Throws an error when algorithm value cannot be returned', async ({
       input: createRequest('keyId="test-key-a", algorithm="RSA-256", created=1402170695, headers="(request-target) (created)", signature="someSignature"'),
       options: defaultOptions,
       expected: new Error(
-        'Algorithm from keyId is not compatible with algorithm signature header parameter'
+        'No entry for this algorithm in algorithmMap'
       )
     },
     {
@@ -64,7 +60,7 @@ test('Throws an error when algorithm value cannot be returned', async ({
       input: createRequest('keyId="test-key-c", algorithm="hs2019", created=1402170695, headers="(request-target) (created)", signature="someSignature"'),
       options: defaultOptions,
       expected: new Error(
-        'No algorithm found in algorithmMap for this keyId'
+        'No entry for this keyId in algorithmMap'
       )
     }
   ]

--- a/lib/getAlgorithm.test.js
+++ b/lib/getAlgorithm.test.js
@@ -12,7 +12,7 @@ function createRequest (signature) {
 }
 
 const defaultOptions = {
-  algorithmMap: {
+  getKeyIdMap: () => ({
     'test-key-a': {
       name: 'hs2019',
       algorithm: 'sha512'
@@ -21,21 +21,21 @@ const defaultOptions = {
       name: 'hs2019',
       algorithm: 'sha256'
     }
-  }
+  })
 }
 
-test('Constructs a matching Digest header from a valid request Digest header and body', async ({
+test('Returns an algorithm string based on Signature header keyId value', async ({
   equal
 }) => {
   const tests = [
     {
-      description: 'Matching Digest header constructed from an incoming request - sha256',
+      description: 'Matching algorithm for test-key-a',
       input: createRequest('keyId="test-key-a", algorithm="hs2019", created=1402170695, headers="(request-target) (created)", signature="someSignature"'),
       options: defaultOptions,
       expected: 'sha512'
     },
     {
-      description: 'Matching Digest header constructed from an incoming request - sha256',
+      description: 'Matching algorithm for test-key-b',
       input: createRequest('keyId="test-key-b", algorithm="hs2019", created=1402170695, headers="(request-target) (created)", signature="someSignature"'),
       options: defaultOptions,
       expected: 'sha256'

--- a/lib/getAlgorithm.test.js
+++ b/lib/getAlgorithm.test.js
@@ -1,0 +1,58 @@
+'use strict'
+
+const { test } = require('tap')
+const getAlgorithm = require('./getAlgorithm')
+
+function createRequest (signature) {
+  return {
+    headers: {
+      signature
+    }
+  }
+}
+
+test('Constructs a matching Digest header from a valid request Digest header and body', async ({
+  equal
+}) => {
+  const tests = [
+    {
+      description: 'Matching Digest header constructed from an incoming request - sha256',
+      input: createRequest('keyId="test-key-a", algorithm="hs2019", created=1402170695, headers="(request-target) (created)", signature="KXUj1H3ZOhv3Nk4xlRLTn4bOMlMOmFiud3VXrMa9MaLCxnVmrqOX5BulRvB65YW/wQp0oT/nNQpXgOYeY8ovmHlpkRyz5buNDqoOpRsCpLGxsIJ9cX8XVsM9jy+Q1+RIlD9wfWoPHhqhoXt35ZkasuIDPF/AETuObs9QydlsqONwbK+TdQguDK/8Va1Pocl6wK1uLwqcXlxhPEb55EmdYB9pddDyHTADING7K4qMwof2mC3t8Pb0yoLZoZX5a4Or4FrCCKK/9BHAhq/RsVk0dTENMbTB4i7cHvKQu+o9xuYWuxyvBa0Z6NdOb0di70cdrSDEsL5Gz7LBY5J2N9KdGg=="'),
+      options: {
+        algorithmMap: {}
+      },
+      expected: 'sha512'
+    }
+  ]
+
+  tests.forEach(({ description, input, options, expected }) => {
+    equal(getAlgorithm(input, options), expected, description)
+  })
+})
+
+test('Throws an error when algorithm cannot be returned', async ({
+  throws
+}) => {
+  const tests = [
+    {
+      description: 'Algorithm from keyId lookup is not compatible with algorithm signature header parameter',
+      input: createRequest(''),
+      options: {
+        algorithmMap: {}
+      },
+      expected: new Error(
+        'Algorithm from keyId is not compatible with algorithm signature header parameter'
+      )
+    }
+  ]
+
+  tests.forEach(({ description, input, options, expected }) => {
+    throws(
+      function () {
+        getAlgorithm(input, options)
+      },
+      expected,
+      description
+    )
+  })
+})

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -16,7 +16,7 @@ function plugin (pluginOptions) {
     getDigest,
     digestEncoding: 'base64',
     getAlgorithm,
-    getKeyIdMap: () => {
+    algorithmMap: () => {
       throw new Error('No getKeyIdMap function provided.')
     },
     getSignatureEncoding: () => {

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -16,9 +16,7 @@ function plugin (pluginOptions) {
     getDigest,
     digestEncoding: 'base64',
     getAlgorithm,
-    algorithmMap: () => {
-      throw new Error('No getKeyIdMap function provided.')
-    },
+    algorithmMap: {},
     getSignatureEncoding: () => {
       throw new Error('No getSignatureEncoding function provided.')
     }

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -16,7 +16,9 @@ function plugin (pluginOptions) {
     getDigest,
     digestEncoding: 'base64',
     getAlgorithm,
-    algorithmMap: {},
+    algorithmMap: () => {
+      throw new Error('No getKeyIdMap function provided.')
+    },
     getSignatureEncoding: () => {
       throw new Error('No getSignatureEncoding function provided.')
     }
@@ -27,32 +29,18 @@ function plugin (pluginOptions) {
     ...pluginOptions
   }
 
-  const optionsTypeValidations = {
-    sharedSecret: 'string',
-    verificationError: 'string',
-    verificationErrorMessage: 'string',
-    extractSignature: () => {},
-    constructSignatureString: () => {},
-    getDigest: () => {},
-    digestEncoding: 'string',
-    getAlgorithm: () => {},
-    algorithmMap: {},
-    getSignatureEncoding: () => {}
-  }
-
-  for (const [key, value] of Object.entries(optionsTypeValidations)) {
-    if (!options[key] || typeof options[key] !== typeof value) {
-      throw new Error(`${key} option does not exist or is not of type ${typeof value}`)
-    }
-  }
-
   function verificationHook (req, reply, next) {
     const {
+      sharedSecret,
       extractSignature,
       constructSignatureString,
       verificationError,
       verificationErrorMessage
     } = options
+
+    if (sharedSecret === null) {
+      return next(new Error('missing shared secret'))
+    }
 
     try {
       if (extractSignature(req) === constructSignatureString(req, options)) {

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -16,9 +16,7 @@ function plugin (pluginOptions) {
     getDigest,
     digestEncoding: 'base64',
     getAlgorithm,
-    algorithmMap: () => {
-      throw new Error('No getKeyIdMap function provided.')
-    },
+    algorithmMap: {},
     getSignatureEncoding: () => {
       throw new Error('No getSignatureEncoding function provided.')
     }
@@ -29,18 +27,32 @@ function plugin (pluginOptions) {
     ...pluginOptions
   }
 
+  const optionsTypeValidations = {
+    sharedSecret: 'string',
+    verificationError: 'string',
+    verificationErrorMessage: 'string',
+    extractSignature: () => {},
+    constructSignatureString: () => {},
+    getDigest: () => {},
+    digestEncoding: 'string',
+    getAlgorithm: () => {},
+    algorithmMap: {},
+    getSignatureEncoding: () => {}
+  }
+
+  for (const [key, value] of Object.entries(optionsTypeValidations)) {
+    if (!options[key] || typeof options[key] !== typeof value) {
+      throw new Error(`${key} option does not exist or is not of type ${typeof value}`)
+    }
+  }
+
   function verificationHook (req, reply, next) {
     const {
-      sharedSecret,
       extractSignature,
       constructSignatureString,
       verificationError,
       verificationErrorMessage
     } = options
-
-    if (sharedSecret === null) {
-      return next(new Error('missing shared secret'))
-    }
 
     try {
       if (extractSignature(req) === constructSignatureString(req, options)) {

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -4,6 +4,7 @@ const createError = require('http-errors')
 const extractSignature = require('./extractSignature')
 const constructSignatureString = require('./constructSignatureString')
 const getDigest = require('./getDigest')
+const getAlgorithm = require('./getAlgorithm')
 
 function plugin (pluginOptions) {
   const defaultOptions = {
@@ -14,8 +15,9 @@ function plugin (pluginOptions) {
     constructSignatureString,
     getDigest,
     digestEncoding: 'base64',
-    getAlgorithm: () => {
-      throw new Error('No getAlgorithm function provided.')
+    getAlgorithm,
+    getKeyIdMap: () => {
+      throw new Error('No getKeyIdMap function provided.')
     },
     getSignatureEncoding: () => {
       throw new Error('No getSignatureEncoding function provided.')


### PR DESCRIPTION
resolves #2 
### Summary
- Created default `getAlgorithm` method that uses a configuration `algorithmMap` object to map Signature `keyId` and `algorithm` properties to the appropriate algorithm.
- Added method tests
- Added new `getAlgorithm` as a plugin default option
- Updated tests for `constructSignatureString` to use default `getAlgoritm` method
- Updated fastify server examples to register plugin with new `algroithmMap` object
- Updated README.md with new methods and examples

### Test Plan
- Run `npm test` to confirm test coverage
- Run either the hook or decorator example server `npm run example:hook -- -l info -w` or `npm run example:decorator -- -l info -w`
  - Use HTTPie to send any or all of the following requests and confirm appropriate responses
```sh
http POST localhost:3000 Signature:'keyId="test-key-a", algorithm="hs2019", headers="(request-target) (created) (expires) host", signature="Nstb3q49bne90WmkbiZ9eyRtKCUmOWvc/kFyw/ftfLtqAXfRZGBk+hSJkXs0GRRm4Q/58c/pdIKj5DND11/fwQ==", created=1402170695, expires=1402170895'
```
```sh
http POST localhost:3000/foo Signature:'keyId="test-key-a", algorithm="hs2019", headers="(request-target) (created) (expires) host", signature="fKj7/7DbxLi1RkMqBrPB6HJ6dXUThRM4nwSErMo3ni1SuXZjTEpNDiZozUMUYqpcGssakLQl2y8ryBz0U5oxlg==", created=1402170695, expires=1402170895'
```
```sh
http POST localhost:3000/ Signature:'keyId="test-key-a", algorithm="hs2019", headers="(request-target) (created) (expires) host digest content-type", signature="pQul5YFrqv76Zq2bE1kWjJfFGnTu0MwU7X7c8MWDswAI5V7dROqKbBWKUGcoysxujgTqkJo/Eg74x34o54hqRg==", created=1402170695, expires=1402170895' Digest:'sha-512=+PtokCNHosgo04ww4cNhd4yJxhMjLzWjDAKtKwQZDT4Ef9v/PrS/+BQLX4IX5dZkUMK/tQo7Uyc68RkhNyCZVg==' hello=world
```
  - Change HTTPie command signature values or signed signature inputs and confirm that appropriate "unauthorized" responses are received. 
