### PR TITLE
Feat/signature encoding options

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,12 @@ Fastify plugin for HMAC signatures.
   - [Route Level Hook Example](#route-level-hook-example)
       - [Run the example:](#run-the-example-1)
 - [Default Methods](#default-methods)
-  - [Default extractSignature Method](#default-extractsignature-method)
-  - [Default constructSignatureString Method](#default-constructsignaturestring-method)
-  - [Default getDigest Method](#default-getdigest-method)
-  - [Default getAlgorithm Method](#default-getalgorithm-method)
-  - [Default getSignatureEncoding Method](#default-getsignatureencoding-method)
+  - [Example Request](#example-request)
+  - [extractSignature Method](#extractsignature-method)
+  - [constructSignatureString Method](#constructsignaturestring-method)
+  - [getDigest Method](#getdigest-method)
+  - [getAlgorithm Method](#getalgorithm-method)
+  - [getSignatureEncoding Method](#getsignatureencoding-method)
 - [Replacing Default Methods](#replacing-default-methods)
   - [Example: Shopify HMAC Query Parameter Verification](#example-shopify-hmac-query-parameter-verification)
     - [Run the example](#run-the-example-2)
@@ -38,16 +39,16 @@ npm i @autotelic/fastify-hmac
 - Register plugin. This will decorate your `fastify` instance with a request method `HMACValidate`.
   - During registration, provide a configuration object that contains the following:
     - A `sharedSecret` string
-    - A `algorithmMap` object that maps Signature header `algorithm` and `keyId` properties to a specific algorithm. See [`getAlgorithm`](#default-getAlgorithm-method) for default structure.
+    - A `algorithmMap` object that maps Signature header `algorithm` and `keyId` properties to a specific algorithm. See [`getAlgorithm`](#getAlgorithm-method) for default structure.
     - Optional configuration properties
       - A `verificationError` string - default: `'Unauthorized'`
       - A `verificationErrorMessage` string - default: `'Signature verification failed'`
       - A `digestEncoding` string - default: `'base64'`
-      - A `getDigest` method - [default](#default-getDigest-method): A method that calculates and verifies a message Digest header to be used as input to the HMAC signature.
-      - A `extractSignature` method - [default](#default-extractSignature-method): A method that extracts properties from a request Signature Header constructed according to [IETF draft standards][1]
-      - A `constructSignatureString` method - [default](#default-constructSignatureString-method): A method that constructs a Signature digest string from the key material detailed in the request Signature header according to [IETF draft standards][1]
-      - A `getAlgorithm` method - [default](#default-getAlgorithm-method): A method that returns an algorithm string from the `algorithmMap` configuration object.
-      - A `getSignatureEncoding` method - [default](#default-getSignatureEncoding-method): A method that returns a `'base64'` encoding string to be used during HMAC signature construction.
+      - A `getDigest` method - [default](#getDigest-method): A method that calculates and verifies a message Digest header to be used as input to the HMAC signature.
+      - A `extractSignature` method - [default](#extractSignature-method): A method that extracts properties from a request Signature Header constructed according to [IETF draft standards][1]
+      - A `constructSignatureString` method - [default](#constructSignatureString-method): A method that constructs a Signature digest string from the key material detailed in the request Signature header according to [IETF draft standards][1]
+      - A `getAlgorithm` method - [default](#getAlgorithm-method): A method that returns an algorithm string from the `algorithmMap` configuration object.
+      - A `getSignatureEncoding` method - [default](#getSignatureEncoding-method): A method that returns a `'base64'` encoding string to be used during HMAC signature construction.
 - Add a [global](#global-hook-example) or [route level](#route-level-hook-example) `preValidation` hook to your application.
   - **Note:** For verification of HMAC signatures that include a body Digest header as HMAC key material, the `validateHMAC` step must take place on the `preValidation` lifecycle step as the fastify request body parsing takes place just prior to `preValidation`. Prior to `preValidation`, `request.body` will always be `null`.
 
@@ -139,77 +140,93 @@ npm run example:decorator -- -l info -w
 
 # Default Methods
 
-## Default extractSignature Method
+## Example Request
 
-The `extractSignature` method returns the HMAC signature string found in a request Signature header constructed according to [IETF draft standards][1]. This signature is compared to the calculated HMAC signature from `constructSignatureString` to validate message authenticity. This method is called with one parameter, the fastify `request` object.
+The following example request object is referenced in the default method documentation.
 
-The method uses an internal helper method `parseSignatureString` to destructure the Signature header string into an object.
+```HTTP
+POST / HTTP/1.1
+Host: localhost:3000
+Signature: keyId="test-key-a", algorithm="hs2019", headers="(request-target) (created) (expires) host digest content-type", signature="pQul5YFrqv76Zq2bE1kWjJfFGnTu0MwU7X7c8MWDswAI5V7dROqKbBWKUGcoysxujgTqkJo/Eg74x34o54hqRg==", created=1402170695, expires=1402170895
+Digest: sha-512=+PtokCNHosgo04ww4cNhd4yJxhMjLzWjDAKtKwQZDT4Ef9v/PrS/+BQLX4IX5dZkUMK/tQo7Uyc68RkhNyCZVg==
+Content-Type: application/json
 
-```js
-extractSignature = (request) => {
-  // ...
-  return `<signature-string>`
-}
+{"hello": "world"}
 ```
 
-## Default constructSignatureString Method
+The documentation assumes the fastify-hmac plugin has been registered with the following options.
 
-The `constructSignatureString` method returns a calculated HMAC signature string. This signature is compared to the HMAC signature string found in the request Signature header to validate message authenticity. This method is called with two parameters, the fastify `request` object and the plugin `options` object.
+```js
+  fastify.register(require('fastify-hmac'), {
+    sharedSecret: 'topSecret',
+    algorithmMap: {
+      hs2019: {
+        'test-key-a': 'sha512'
+      }
+    }
+  })
+```
 
-The default method:
-1. Calls `getAlgorithm` from the plugin options object and uses its return value along with the `sharedSecret` property from the plugin options object to create a new HMAC object
+## extractSignature Method
+
+The `extractSignature` method returns the HMAC signature string found in a request Signature header constructed according to [IETF draft standards][1].
+
+This method is called with two parameters, the fastify `request` object and the plugin `options` object.
+
+This signature is compared to the calculated HMAC signature from `constructSignatureString` to validate message authenticity.
+
+
+Given the [Example Request](#example-request) this method will:
+1. Parse the `request` Signature header string
+2.  Return the signature property value: `"pQul5YFrqv76Zq2bE1kWjJfFGnTu0MwU7X7c8MWDswAI5V7dROqKbBWKUGcoysxujgTqkJo/Eg74x34o54hqRg=="`.
+
+## constructSignatureString Method
+
+The `constructSignatureString` method returns a calculated HMAC signature string. 
+
+This method is called with two parameters, the fastify `request` object and the plugin `options` object.
+
+This signature is compared to the HMAC signature string found in the request Signature header to validate message authenticity. 
+
+
+Given the [Example Request](#example-request) this method will:
+1. Calls [`getAlgorithm`](#getAlgorithm-Method) from the plugin `options` object and uses its return value along with the `sharedSecret` property from the plugin `options` object to create a new HMAC object
 2. Updates the HMAC object with the signature content string obtained from `getMessage`
-3. Returns a calculated digest string encoded with the digest encoding string returned from `getSignatureEncoding` from the plugin options object.
+   1. The `getMessage` function returns a formatted string according to [IETF draft standards][1] containing the Signature content listed under `headers` in the `request` Signature header.
+3. Encodes the signature with the digest encoding string returned from [`getSignatureEncoding`](#getSignatureEncoding-Method) in the plugin `options` object.
+4. Returns the calculated signature string of: `"pQul5YFrqv76Zq2bE1kWjJfFGnTu0MwU7X7c8MWDswAI5V7dROqKbBWKUGcoysxujgTqkJo/Eg74x34o54hqRg=="`
 
-The `getMessage` function returns a formatted string according to [IETF draft standards][1] containing the Signature content listed under `headers` in the request Signature header.
+## getDigest Method
 
-`getMessage` also uses an internal helper method `parseSignatureString` to destructure the Signature header string into an object.
+The `getDigest` method returns a Digest header string to be used when assembling the HMAC signature input. 
 
-```js
-constructSignatureString = (request, options) => {
-  // ...
-  return `<signature-string>`
-}
-```
+This method is called with two parameters, the fastify `request` object and the plugin `options` object. 
 
-## Default getDigest Method
-
-The `getDigest` method returns a Digest header string to be used when assembling the HMAC signature input. This method is called with two parameters, the fastify `request` object and the plugin `options` object. 
-
-The default method:
-1. Parses the request Digest header to determine the appropriate hashing algorithm
-2. Hashes the request body using the algorithm
-3. Applies the digest encoding found in options property `digestEncoding` - default: `'base64'`
-3. Compares the new digest value with the value in the request Digest header
+Given the [Example Request](#example-request) this method will:
+1. Parse the `request` Digest header to determine the appropriate hashing algorithm
+2. Hashes the `request` body using the algorithm
+3. Applies the digest encoding found in `options` property `digestEncoding` - default: `'base64'`
+3. Compares the new digest value with the value in the `request` Digest header
    - This will throw an error if the two values do not match
-4. Reconstructs the digest header and returns a string in the format `<digest-algorithm>=<digest-value>`
+4. Reconstructs the digest header and returns: `"sha-512=+PtokCNHosgo04ww4cNhd4yJxhMjLzWjDAKtKwQZDT4Ef9v/PrS/+BQLX4IX5dZkUMK/tQo7Uyc68RkhNyCZVg=="`
 
 **Note:** The default method assumes:
 1. The Digest value is a hash of only the request body
 2. The body content is always JSON
 3. The request Digest header only contains a single digest value
 
-```js
-getDigest = (request, options) => {
-  // ...
-  return `<digest-algorithm>=<digest-value>`
-}
-```
+## getAlgorithm Method
 
-## Default getAlgorithm Method
+The `getAlgorithm` method returns a HMAC algorithm string to be used when generating a HMAC signature.
 
-The `getAlgorithm` method returns a HMAC algorithm string to be used when generating a HMAC signature. This method is called with two parameters, the fastify `request` object and the plugin `options` object. The default method uses the `algorithmMap` object provided as an option during plugin registration with the `keyId` and `algorithm` Signature header properties to look up and return the appropriate algorithm string. e.g. `'sha256'` or `'sha512'`
+This method is called with two parameters, the fastify `request` object and the plugin `options` object.
 
-The method uses an internal helper method `parseSignatureString` to destructure the Signature header string into an object.
+Given the [Example Request](#example-request) this method will:
+1. Parse the `keyId` and `algorithm` Signature header properties from the `request`
+2. Use the `algorithm` and `keyId` values to look up an algorithm string in `algorithmMap` from the plugin `options`
+3. Return the algorithm string of `"sha512"`
 
-```js
-getAlgorithm = (request, options) => {
-  // ...
-  return '<valid-algorithm-string>'
-}
-```
-
-For the default `getAlgorithm` an `algorithmMap` object matching the following format is expected:
+For the default `getAlgorithm`, an `algorithmMap` object matching the following format is expected:
 
 ```js
 {
@@ -227,22 +244,21 @@ const algorithmMap = {
 }
 ```
 
-## Default getSignatureEncoding Method
+## getSignatureEncoding Method
 
-The `getSignatureEncoding` method returns a digest encoding string to be used when generating a HMAC signature. This method is called with two parameters, the fastify `request` object and the plugin `options` object. The default method simply returns `'base64'`. 
+The `getSignatureEncoding` method returns a digest encoding string to be used when generating a HMAC signature.
 
-```js
-getSignatureEncoding = (request, options) => {
-  // ...
-  return '<valid-encoding-string>'
-}
-```
+This method is called with two parameters, the fastify `request` object and the plugin `options` object.
+
+The default method simply returns `"base64"`. 
 
 # Replacing Default Methods
 
 ## Example: Shopify HMAC Query Parameter Verification
 
-The `extractSignature`, `constructSignatureString`, `getAlgorithm` and `getSignatureEncoding` methods can also be entirely replaced during registration by passing in new methods. This example shows how the plugin can be modified to verify Shopify Query String HMAC parameters instead of Signature headers. 
+The `extractSignature`, `constructSignatureString`, `getAlgorithm` and `getSignatureEncoding` methods can also be entirely replaced during registration by passing in new methods. 
+
+This example shows how the plugin can be modified to verify Shopify Query String HMAC parameters instead of Signature headers. 
 
 ```js
 const {

--- a/README.md
+++ b/README.md
@@ -1,20 +1,38 @@
-# fastify-hmac
-
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](http://standardjs.com/)
+
+<!-- omit in toc -->
+# fastify-hmac
 
 Fastify plugin for HMAC signatures.
 
-## How it works
+- [1. How it works](#1-how-it-works)
+- [2. Install](#2-install)
+- [3. Usage](#3-usage)
+  - [3.1. Global Hook Example](#31-global-hook-example)
+    - [3.1.1. Run the example:](#311-run-the-example)
+  - [3.2. Route Level Hook Example](#32-route-level-hook-example)
+      - [3.2.0.1. Run the example:](#3201-run-the-example)
+  - [3.3. Example: Shopify HMAC Query Parameter Verification](#33-example-shopify-hmac-query-parameter-verification)
+    - [3.3.1. Run the example](#331-run-the-example)
+- [4. Default Methods](#4-default-methods)
+  - [4.1. Default extractSignature Method](#41-default-extractsignature-method)
+  - [4.2. Default constructSignatureString Method](#42-default-constructsignaturestring-method)
+  - [4.3. Default getDigest Method](#43-default-getdigest-method)
+  - [4.4. Default getAlgorithm Method](#44-default-getalgorithm-method)
+  - [4.5. Default getSignatureEncoding Method](#45-default-getsignatureencoding-method)
+- [5. License](#5-license)
+
+# 1. How it works
 
 Verifies that http messages are signed according to [IETF draft standards][1].
 
-## Install
+# 2. Install
 
 ```shell
 npm i @autotelic/fastify-hmac
 ```
 
-## Usage
+# 3. Usage
 
 - Register plugin. This will decorate your `fastify` instance with a request method `HMACValidate`.
   - During registration, provide a configuration object that contains the following:
@@ -32,7 +50,7 @@ npm i @autotelic/fastify-hmac
 - Add a [global](#global-hook-example) or [route level](#route-level-hook-example) `preValidation` hook to your application.
   - **Note:** For verification of HMAC signatures that include a body Digest header as HMAC key material, the `validateHMAC` step must take place on the `preValidation` lifecycle step as the fastify request body parsing takes place just prior to `preValidation`. Prior to `preValidation`, `request.body` will always be `null`.
 
-### Global Hook Example
+## 3.1. Global Hook Example
 
 ```js
 module.exports = function (fastify, options, next) {
@@ -67,13 +85,13 @@ module.exports = function (fastify, options, next) {
 }
 ```
 
-#### Run the example:
+### 3.1.1. Run the example:
 
 ```
 npm run example:hook -- -l info -w
 ```
 
-### Route Level Hook Example
+## 3.2. Route Level Hook Example
 
 ```js
 module.exports = function (fastify, options, next) {
@@ -112,13 +130,13 @@ module.exports = function (fastify, options, next) {
 }
 ```
 
-#### Run the example:
+#### 3.2.0.1. Run the example:
 
 ```
 npm run example:decorator -- -l info -w
 ```
 
-### Example: Shopify HMAC Query Parameter Verification
+## 3.3. Example: Shopify HMAC Query Parameter Verification
 
 The `extractSignature`, `constructSignatureString`, `getAlgorithm` and `getSignatureEncoding` methods can also be entirely replaced during registration by passing in new methods. This example shows how this plugin can be modified to verify Shopify Query String HMAC parameters instead of Signature headers. 
 
@@ -154,30 +172,113 @@ module.exports = function (fastify, options, next) {
 }
 ```
 
-#### Run the example
+### 3.3.1. Run the example
 ```sh
 npm run example:shopify -- -l info -w
 ```
+# 4. Default Methods
 
-## Default extractSignature Method
+## 4.1. Default extractSignature Method
 
-**TODO**
+The `extractSignature` method returns the HMAC signature string found in the request Signature header. This signature is compared to the calculated HMAC signature to validate message authenticity. This method is called with one parameter, the fastify `request` object.
 
-## Default constructSignatureString Method
+The method uses an internal helper method `parseSignatureString` to destructure the Signature header string into an object.
 
-**TODO**
+```js
+extractSignature = (request) => {
+  // ...
+  return `<signature-string>`
+}
+```
 
-## Default getDigest Method
+## 4.2. Default constructSignatureString Method
 
-**TODO**
+The `constructSignatureString` method returns a calculated HMAC signature string. This signature is compared to the HMAC signature string found in the request Signature header to validate message authenticity. This method is called with two parameters, the fastify `request` object and the plugin `options` object.
 
-## Default getAlgorithm Method
+The default method:
+1. Calls `getAlgorithm` from the plugin options object and uses its return value along with the `sharedSecret` property from the plugin options object to create a new HMAC object
+2. Updates the HMAC object with the signature content string obtained from `getMessage`
+3. Returns a calculated digest string encoded with the digest encoding string returned from `getSignatureEncoding` from the plugin options object.
 
-**TODO**
+The `getMessage` function returns a formatted string according to [IETF draft standards][1]containing the Signature content listed under `headers` in the request Signature header.
 
-## License
+`getMessage` also uses an internal helper method `parseSignatureString` to destructure the Signature header string into an object.
+
+```js
+constructSignatureString = (request, options) => {
+  // ...
+  return `<signature-string>`
+}
+```
+
+## 4.3. Default getDigest Method
+
+The `getDigest` method returns a Digest header string to be used when assembling the HMAC signature input. This method is called with two parameters, the fastify `request` object and the plugin `options` object. 
+
+The default method:
+1. Parses the request Digest header to determine the appropriate hashing algorithm
+2. Hashes the request body using the algorithm
+3. Applies the digest encoding found in options property `digestEncoding` - default: `'base64'`
+3. Compares the new digest value with the value in the request Digest header
+   - This will throw an error if the two values do not match
+4. Reconstructs the digest header and returns a string in the format `<digest-algorithm>=<digest-value>`
+
+**Note:** The default method assumes:
+1. The Digest value is a hash of only the request body
+2. The body content is always JSON
+3. The request Digest header only contains a single digest value
+
+```js
+getDigest = (request, options) => {
+  // ...
+  return `<digest-algorithm>=<digest-value>`
+}
+```
+
+## 4.4. Default getAlgorithm Method
+
+The `getAlgorithm` method returns a HMAC algorithm string to be used when generating a HMAC signature. This method is called with two parameters, the fastify `request` object and the plugin `options` object. The default method uses the `algorithmMap` object provided as an option during plugin registration with the `keyId` and `algorithm` Signature header properties to look up and return the appropriate algorithm string. e.g. `'sha256'` or `'sha512'`
+
+The method uses an internal helper method `parseSignatureString` to destructure the Signature header string into an object.
+
+```js
+getAlgorithm = (request, options) => {
+  // ...
+  return '<valid-algorithm-string>'
+}
+```
+
+For the default `getAlgorithm` an `algorithmMap` object matching the following format is expected:
+
+```js
+{
+// const algorithmMap = {
+//   [algorithm]: {
+//     [keyId]: [algorithmString]
+//   } 
+// }
+
+const algorithmMap = {
+  hs2019: {
+    'test-key-a': 'sha512',
+    'test-key-b': 'sha256'
+  } 
+}
+```
+
+## 4.5. Default getSignatureEncoding Method
+
+The `getSignatureEncoding` method returns a digest encoding string to be used when generating a HMAC signature. This method is called with two parameters, the fastify `request` object and the plugin `options` object. The default method simply returns `'base64'`. 
+
+```js
+getSignatureEncoding = (request, options) => {
+  // ...
+  return '<valid-encoding-string>'
+}
+```
+
+# 5. License
 
 MIT
-
 
 [1]: https://datatracker.ietf.org/doc/draft-ietf-httpbis-message-signatures/

--- a/README.md
+++ b/README.md
@@ -5,34 +5,35 @@
 
 Fastify plugin for HMAC signatures.
 
-- [1. How it works](#1-how-it-works)
-- [2. Install](#2-install)
-- [3. Usage](#3-usage)
-  - [3.1. Global Hook Example](#31-global-hook-example)
-    - [3.1.1. Run the example:](#311-run-the-example)
-  - [3.2. Route Level Hook Example](#32-route-level-hook-example)
-      - [3.2.0.1. Run the example:](#3201-run-the-example)
-  - [3.3. Example: Shopify HMAC Query Parameter Verification](#33-example-shopify-hmac-query-parameter-verification)
-    - [3.3.1. Run the example](#331-run-the-example)
-- [4. Default Methods](#4-default-methods)
-  - [4.1. Default extractSignature Method](#41-default-extractsignature-method)
-  - [4.2. Default constructSignatureString Method](#42-default-constructsignaturestring-method)
-  - [4.3. Default getDigest Method](#43-default-getdigest-method)
-  - [4.4. Default getAlgorithm Method](#44-default-getalgorithm-method)
-  - [4.5. Default getSignatureEncoding Method](#45-default-getsignatureencoding-method)
-- [5. License](#5-license)
+- [How it works](#how-it-works)
+- [Install](#install)
+- [Usage](#usage)
+  - [Global Hook Example](#global-hook-example)
+    - [Run the example:](#run-the-example)
+  - [Route Level Hook Example](#route-level-hook-example)
+      - [Run the example:](#run-the-example-1)
+- [Default Methods](#default-methods)
+  - [Default extractSignature Method](#default-extractsignature-method)
+  - [Default constructSignatureString Method](#default-constructsignaturestring-method)
+  - [Default getDigest Method](#default-getdigest-method)
+  - [Default getAlgorithm Method](#default-getalgorithm-method)
+  - [Default getSignatureEncoding Method](#default-getsignatureencoding-method)
+- [Replacing Default Methods](#replacing-default-methods)
+  - [Example: Shopify HMAC Query Parameter Verification](#example-shopify-hmac-query-parameter-verification)
+    - [Run the example](#run-the-example-2)
+- [License](#license)
 
-# 1. How it works
+# How it works
 
 Verifies that http messages are signed according to [IETF draft standards][1].
 
-# 2. Install
+# Install
 
 ```shell
 npm i @autotelic/fastify-hmac
 ```
 
-# 3. Usage
+# Usage
 
 - Register plugin. This will decorate your `fastify` instance with a request method `HMACValidate`.
   - During registration, provide a configuration object that contains the following:
@@ -50,7 +51,7 @@ npm i @autotelic/fastify-hmac
 - Add a [global](#global-hook-example) or [route level](#route-level-hook-example) `preValidation` hook to your application.
   - **Note:** For verification of HMAC signatures that include a body Digest header as HMAC key material, the `validateHMAC` step must take place on the `preValidation` lifecycle step as the fastify request body parsing takes place just prior to `preValidation`. Prior to `preValidation`, `request.body` will always be `null`.
 
-## 3.1. Global Hook Example
+## Global Hook Example
 
 ```js
 module.exports = function (fastify, options, next) {
@@ -85,13 +86,13 @@ module.exports = function (fastify, options, next) {
 }
 ```
 
-### 3.1.1. Run the example:
+### Run the example:
 
 ```
 npm run example:hook -- -l info -w
 ```
 
-## 3.2. Route Level Hook Example
+## Route Level Hook Example
 
 ```js
 module.exports = function (fastify, options, next) {
@@ -130,15 +131,118 @@ module.exports = function (fastify, options, next) {
 }
 ```
 
-#### 3.2.0.1. Run the example:
+#### Run the example:
 
 ```
 npm run example:decorator -- -l info -w
 ```
 
-## 3.3. Example: Shopify HMAC Query Parameter Verification
+# Default Methods
 
-The `extractSignature`, `constructSignatureString`, `getAlgorithm` and `getSignatureEncoding` methods can also be entirely replaced during registration by passing in new methods. This example shows how this plugin can be modified to verify Shopify Query String HMAC parameters instead of Signature headers. 
+## Default extractSignature Method
+
+The `extractSignature` method returns the HMAC signature string found in the request Signature header. This signature is compared to the calculated HMAC signature to validate message authenticity. This method is called with one parameter, the fastify `request` object.
+
+The method uses an internal helper method `parseSignatureString` to destructure the Signature header string into an object.
+
+```js
+extractSignature = (request) => {
+  // ...
+  return `<signature-string>`
+}
+```
+
+## Default constructSignatureString Method
+
+The `constructSignatureString` method returns a calculated HMAC signature string. This signature is compared to the HMAC signature string found in the request Signature header to validate message authenticity. This method is called with two parameters, the fastify `request` object and the plugin `options` object.
+
+The default method:
+1. Calls `getAlgorithm` from the plugin options object and uses its return value along with the `sharedSecret` property from the plugin options object to create a new HMAC object
+2. Updates the HMAC object with the signature content string obtained from `getMessage`
+3. Returns a calculated digest string encoded with the digest encoding string returned from `getSignatureEncoding` from the plugin options object.
+
+The `getMessage` function returns a formatted string according to [IETF draft standards][1]containing the Signature content listed under `headers` in the request Signature header.
+
+`getMessage` also uses an internal helper method `parseSignatureString` to destructure the Signature header string into an object.
+
+```js
+constructSignatureString = (request, options) => {
+  // ...
+  return `<signature-string>`
+}
+```
+
+## Default getDigest Method
+
+The `getDigest` method returns a Digest header string to be used when assembling the HMAC signature input. This method is called with two parameters, the fastify `request` object and the plugin `options` object. 
+
+The default method:
+1. Parses the request Digest header to determine the appropriate hashing algorithm
+2. Hashes the request body using the algorithm
+3. Applies the digest encoding found in options property `digestEncoding` - default: `'base64'`
+3. Compares the new digest value with the value in the request Digest header
+   - This will throw an error if the two values do not match
+4. Reconstructs the digest header and returns a string in the format `<digest-algorithm>=<digest-value>`
+
+**Note:** The default method assumes:
+1. The Digest value is a hash of only the request body
+2. The body content is always JSON
+3. The request Digest header only contains a single digest value
+
+```js
+getDigest = (request, options) => {
+  // ...
+  return `<digest-algorithm>=<digest-value>`
+}
+```
+
+## Default getAlgorithm Method
+
+The `getAlgorithm` method returns a HMAC algorithm string to be used when generating a HMAC signature. This method is called with two parameters, the fastify `request` object and the plugin `options` object. The default method uses the `algorithmMap` object provided as an option during plugin registration with the `keyId` and `algorithm` Signature header properties to look up and return the appropriate algorithm string. e.g. `'sha256'` or `'sha512'`
+
+The method uses an internal helper method `parseSignatureString` to destructure the Signature header string into an object.
+
+```js
+getAlgorithm = (request, options) => {
+  // ...
+  return '<valid-algorithm-string>'
+}
+```
+
+For the default `getAlgorithm` an `algorithmMap` object matching the following format is expected:
+
+```js
+{
+// const algorithmMap = {
+//   [algorithm]: {
+//     [keyId]: [algorithmString]
+//   } 
+// }
+
+const algorithmMap = {
+  hs2019: {
+    'test-key-a': 'sha512',
+    'test-key-b': 'sha256'
+  } 
+}
+```
+
+## Default getSignatureEncoding Method
+
+The `getSignatureEncoding` method returns a digest encoding string to be used when generating a HMAC signature. This method is called with two parameters, the fastify `request` object and the plugin `options` object. The default method simply returns `'base64'`. 
+
+```js
+getSignatureEncoding = (request, options) => {
+  // ...
+  return '<valid-encoding-string>'
+}
+```
+
+# Replacing Default Methods
+
+## Example: Shopify HMAC Query Parameter Verification
+
+The `extractSignature`, `constructSignatureString`, `getAlgorithm` and `getSignatureEncoding` methods can also be entirely replaced during registration by passing in new methods. This example shows how the plugin can be modified to verify Shopify Query String HMAC parameters instead of Signature headers. 
 
 ```js
 const {
@@ -172,112 +276,12 @@ module.exports = function (fastify, options, next) {
 }
 ```
 
-### 3.3.1. Run the example
+### Run the example
 ```sh
 npm run example:shopify -- -l info -w
 ```
-# 4. Default Methods
 
-## 4.1. Default extractSignature Method
-
-The `extractSignature` method returns the HMAC signature string found in the request Signature header. This signature is compared to the calculated HMAC signature to validate message authenticity. This method is called with one parameter, the fastify `request` object.
-
-The method uses an internal helper method `parseSignatureString` to destructure the Signature header string into an object.
-
-```js
-extractSignature = (request) => {
-  // ...
-  return `<signature-string>`
-}
-```
-
-## 4.2. Default constructSignatureString Method
-
-The `constructSignatureString` method returns a calculated HMAC signature string. This signature is compared to the HMAC signature string found in the request Signature header to validate message authenticity. This method is called with two parameters, the fastify `request` object and the plugin `options` object.
-
-The default method:
-1. Calls `getAlgorithm` from the plugin options object and uses its return value along with the `sharedSecret` property from the plugin options object to create a new HMAC object
-2. Updates the HMAC object with the signature content string obtained from `getMessage`
-3. Returns a calculated digest string encoded with the digest encoding string returned from `getSignatureEncoding` from the plugin options object.
-
-The `getMessage` function returns a formatted string according to [IETF draft standards][1]containing the Signature content listed under `headers` in the request Signature header.
-
-`getMessage` also uses an internal helper method `parseSignatureString` to destructure the Signature header string into an object.
-
-```js
-constructSignatureString = (request, options) => {
-  // ...
-  return `<signature-string>`
-}
-```
-
-## 4.3. Default getDigest Method
-
-The `getDigest` method returns a Digest header string to be used when assembling the HMAC signature input. This method is called with two parameters, the fastify `request` object and the plugin `options` object. 
-
-The default method:
-1. Parses the request Digest header to determine the appropriate hashing algorithm
-2. Hashes the request body using the algorithm
-3. Applies the digest encoding found in options property `digestEncoding` - default: `'base64'`
-3. Compares the new digest value with the value in the request Digest header
-   - This will throw an error if the two values do not match
-4. Reconstructs the digest header and returns a string in the format `<digest-algorithm>=<digest-value>`
-
-**Note:** The default method assumes:
-1. The Digest value is a hash of only the request body
-2. The body content is always JSON
-3. The request Digest header only contains a single digest value
-
-```js
-getDigest = (request, options) => {
-  // ...
-  return `<digest-algorithm>=<digest-value>`
-}
-```
-
-## 4.4. Default getAlgorithm Method
-
-The `getAlgorithm` method returns a HMAC algorithm string to be used when generating a HMAC signature. This method is called with two parameters, the fastify `request` object and the plugin `options` object. The default method uses the `algorithmMap` object provided as an option during plugin registration with the `keyId` and `algorithm` Signature header properties to look up and return the appropriate algorithm string. e.g. `'sha256'` or `'sha512'`
-
-The method uses an internal helper method `parseSignatureString` to destructure the Signature header string into an object.
-
-```js
-getAlgorithm = (request, options) => {
-  // ...
-  return '<valid-algorithm-string>'
-}
-```
-
-For the default `getAlgorithm` an `algorithmMap` object matching the following format is expected:
-
-```js
-{
-// const algorithmMap = {
-//   [algorithm]: {
-//     [keyId]: [algorithmString]
-//   } 
-// }
-
-const algorithmMap = {
-  hs2019: {
-    'test-key-a': 'sha512',
-    'test-key-b': 'sha256'
-  } 
-}
-```
-
-## 4.5. Default getSignatureEncoding Method
-
-The `getSignatureEncoding` method returns a digest encoding string to be used when generating a HMAC signature. This method is called with two parameters, the fastify `request` object and the plugin `options` object. The default method simply returns `'base64'`. 
-
-```js
-getSignatureEncoding = (request, options) => {
-  // ...
-  return '<valid-encoding-string>'
-}
-```
-
-# 5. License
+# License
 
 MIT
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ npm run example:decorator -- -l info -w
 
 ## Default extractSignature Method
 
-The `extractSignature` method returns the HMAC signature string found in the request Signature header. This signature is compared to the calculated HMAC signature to validate message authenticity. This method is called with one parameter, the fastify `request` object.
+The `extractSignature` method returns the HMAC signature string found in a request Signature header constructed according to [IETF draft standards][1]. This signature is compared to the calculated HMAC signature from `constructSignatureString` to validate message authenticity. This method is called with one parameter, the fastify `request` object.
 
 The method uses an internal helper method `parseSignatureString` to destructure the Signature header string into an object.
 
@@ -161,7 +161,7 @@ The default method:
 2. Updates the HMAC object with the signature content string obtained from `getMessage`
 3. Returns a calculated digest string encoded with the digest encoding string returned from `getSignatureEncoding` from the plugin options object.
 
-The `getMessage` function returns a formatted string according to [IETF draft standards][1]containing the Signature content listed under `headers` in the request Signature header.
+The `getMessage` function returns a formatted string according to [IETF draft standards][1] containing the Signature content listed under `headers` in the request Signature header.
 
 `getMessage` also uses an internal helper method `parseSignatureString` to destructure the Signature header string into an object.
 

--- a/README.md
+++ b/README.md
@@ -20,15 +20,15 @@ npm i @autotelic/fastify-hmac
   - During registration, provide a configuration object that contains the following:
     - A `sharedSecret` string
     - A `algorithmMap` object that maps Signature header `algorithm` and `keyId` properties to a specific algorithm. See [`getAlgorithm`](#default-getAlgorithm-method) for default structure.
-    - A `getSignatureEncoding` function that returns a encoding string to be used during HMAC signature construction. e.g. `'base64'` or `'hex'`
     - Optional configuration properties
-      - A `verificationError` string - default: 'Unauthorized'
-      - A `verificationErrorMessage` string - default: 'Signature verification failed'
-      - A `digestEncoding` sting - default: 'base64'
+      - A `verificationError` string - default: `'Unauthorized'`
+      - A `verificationErrorMessage` string - default: `'Signature verification failed'`
+      - A `digestEncoding` string - default: `'base64'`
       - A `getDigest` method - [default](#default-getDigest-method): A method that calculates and verifies a message Digest header to be used as input to the HMAC signature.
       - A `extractSignature` method - [default](#default-extractSignature-method): A method that extracts properties from a request Signature Header constructed according to [IETF draft standards][1]
       - A `constructSignatureString` method - [default](#default-constructSignatureString-method): A method that constructs a Signature digest string from the key material detailed in the request Signature header according to [IETF draft standards][1]
       - A `getAlgorithm` method - [default](#default-getAlgorithm-method): A method that returns an algorithm string from the `algorithmMap` configuration object.
+      - A `getSignatureEncoding` method - [default](#default-getSignatureEncoding-method): A method that returns a `'base64'` encoding string to be used during HMAC signature construction.
 - Add a [global](#global-hook-example) or [route level](#route-level-hook-example) `preValidation` hook to your application.
   - **Note:** For verification of HMAC signatures that include a body Digest header as HMAC key material, the `validateHMAC` step must take place on the `preValidation` lifecycle step as the fastify request body parsing takes place just prior to `preValidation`. Prior to `preValidation`, `request.body` will always be `null`.
 
@@ -43,8 +43,7 @@ module.exports = function (fastify, options, next) {
         'test-key-a': 'sha512',
         'test-key-b': 'sha256'
       }
-    },
-    getSignatureEncoding: () => 'base64'
+    }
   })
   fastify.addHook('preValidation', (request, reply, next) => {
     try {
@@ -85,8 +84,7 @@ module.exports = function (fastify, options, next) {
         'test-key-a': 'sha512',
         'test-key-b': 'sha256'
       }
-    },
-    getSignatureEncoding: () => 'base64'
+    }
   })
 
   fastify.decorate('verifyHMAC', function (request, reply, next) {
@@ -122,7 +120,7 @@ npm run example:decorator -- -l info -w
 
 ### Example: Shopify HMAC Query Parameter Verification
 
-The `extractSignature`, `constructSignatureString` and `getAlgorithm` methods can also be entirely replaced during registration by passing in new methods. This example shows how this plugin can be modified to verify Shopify Query String HMAC parameters instead of Signature headers. 
+The `extractSignature`, `constructSignatureString`, `getAlgorithm` and `getSignatureEncoding` methods can also be entirely replaced during registration by passing in new methods. This example shows how this plugin can be modified to verify Shopify Query String HMAC parameters instead of Signature headers. 
 
 ```js
 const {

--- a/README.md
+++ b/README.md
@@ -190,11 +190,11 @@ This signature is compared to the HMAC signature string found in the request Sig
 
 
 Given the [Example Request](#example-request) this method will:
-1. Calls [`getAlgorithm`](#getAlgorithm-Method) from the plugin `options` object and uses its return value along with the `sharedSecret` property from the plugin `options` object to create a new HMAC object
-2. Updates the HMAC object with the signature content string obtained from `getMessage`
+1. Call [`getAlgorithm`](#getAlgorithm-Method) from the plugin `options` object and use its return value along with the `sharedSecret` property from the plugin `options` object to create a new HMAC object
+2. Update the HMAC object with the signature content string obtained from `getMessage`
    1. The `getMessage` function returns a formatted string according to [IETF draft standards][1] containing the Signature content listed under `headers` in the `request` Signature header.
-3. Encodes the signature with the digest encoding string returned from [`getSignatureEncoding`](#getSignatureEncoding-Method) in the plugin `options` object.
-4. Returns the calculated signature string of: `"pQul5YFrqv76Zq2bE1kWjJfFGnTu0MwU7X7c8MWDswAI5V7dROqKbBWKUGcoysxujgTqkJo/Eg74x34o54hqRg=="`
+3. Encode the signature with the digest encoding string returned from [`getSignatureEncoding`](#getSignatureEncoding-Method) in the plugin `options` object.
+4. Return the calculated signature string of: `"pQul5YFrqv76Zq2bE1kWjJfFGnTu0MwU7X7c8MWDswAI5V7dROqKbBWKUGcoysxujgTqkJo/Eg74x34o54hqRg=="`
 
 ## getDigest Method
 
@@ -204,11 +204,11 @@ This method is called with two parameters, the fastify `request` object and the 
 
 Given the [Example Request](#example-request) this method will:
 1. Parse the `request` Digest header to determine the appropriate hashing algorithm
-2. Hashes the `request` body using the algorithm
-3. Applies the digest encoding found in `options` property `digestEncoding` - default: `'base64'`
-3. Compares the new digest value with the value in the `request` Digest header
+2. Hash the `request` body using the algorithm
+3. Apply the digest encoding found in `options` property `digestEncoding` - default: `'base64'`
+3. Compare the new digest value with the value in the `request` Digest header
    - This will throw an error if the two values do not match
-4. Reconstructs the digest header and returns: `"sha-512=+PtokCNHosgo04ww4cNhd4yJxhMjLzWjDAKtKwQZDT4Ef9v/PrS/+BQLX4IX5dZkUMK/tQo7Uyc68RkhNyCZVg=="`
+4. Reconstruct the digest header and return: `"sha-512=+PtokCNHosgo04ww4cNhd4yJxhMjLzWjDAKtKwQZDT4Ef9v/PrS/+BQLX4IX5dZkUMK/tQo7Uyc68RkhNyCZVg=="`
 
 **Note:** The default method assumes:
 1. The Digest value is a hash of only the request body

--- a/examples/exampleDecorator.js
+++ b/examples/exampleDecorator.js
@@ -10,8 +10,7 @@ module.exports = function (fastify, options, next) {
         'test-key-a': 'sha512',
         'test-key-b': 'sha256'
       }
-    },
-    getSignatureEncoding: () => 'base64'
+    }
   })
 
   fastify.decorate('verifyHMAC', function (request, reply, next) {

--- a/examples/exampleHook.js
+++ b/examples/exampleHook.js
@@ -10,8 +10,7 @@ module.exports = function (fastify, options, next) {
         'test-key-a': 'sha512',
         'test-key-b': 'sha256'
       }
-    },
-    getSignatureEncoding: () => 'base64'
+    }
   })
   fastify.addHook('preValidation', (request, reply, next) => {
     try {

--- a/lib/constructSignatureString.js
+++ b/lib/constructSignatureString.js
@@ -8,7 +8,7 @@ const constructSignatureString = (req, options) =>
     algorithm: options.getAlgorithm(req, options),
     sharedSecret: options.sharedSecret,
     message: getMessage(req, options),
-    encoding: options.getSignatureEncoding()
+    encoding: options.getSignatureEncoding(req, options)
   })
 
 const getMessage = (req, options) => {

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -39,7 +39,7 @@ function plugin (pluginOptions) {
     }
 
     try {
-      if (extractSignature(req) === constructSignatureString(req, options)) {
+      if (extractSignature(req, options) === constructSignatureString(req, options)) {
         return next()
       }
     } catch (error) {

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -17,9 +17,7 @@ function plugin (pluginOptions) {
     digestEncoding: 'base64',
     getAlgorithm,
     algorithmMap: {},
-    getSignatureEncoding: () => {
-      throw new Error('No getSignatureEncoding function provided.')
-    }
+    getSignatureEncoding: () => 'base64'
   }
 
   const options = {


### PR DESCRIPTION
resolves #3 and resolves #11 

### Summary
- Changed default option for `getSignatureEncoding` from an error to the default of `base64`
- Updated documentation and examples to match
- Added documentation for default methods

### Test Plan
- Plugin functionality is largely unchanged but all previous test cases can be re-run #21 
- Review documentation format and content
