### PR TITLE
Build/auto release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Validate & Release
+on:
+  push:
+    tags:
+      - v*
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - run: npm run lint
+      - run: npm test
+
+  publish-npm:
+    runs-on: ubuntu-latest
+    needs: validate
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+        registry-url: https://registry.npmjs.org/
+    - run: npm publish --access public
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autotelic/fastify-hmac",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "HMAC signature verification for fastify",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
resolves #18 

### Summary
- Added a `release.yml` gitHub action
- Added `NPM_PUBLISH_TOKEN` secret to repository

### Questions/Discussion
- See comments
- Do we want every push that matches the tag pattern to trigger a release or just push/pull requests on specific branches?
  - Which branch(es)?
- Technically the next published version should be a major version because there are breaking changed to the API but are we ready for v1.0.0 yet? Should this be a "pre-production" minor version release?